### PR TITLE
fix(ui-build): Set a relative base path for KAOTO_API

### DIFF
--- a/Dockerfile.jvm
+++ b/Dockerfile.jvm
@@ -5,7 +5,7 @@ WORKDIR /app
 RUN git clone --depth 1 --branch ${UI_TAG} https://github.com/KaotoIO/kaoto-ui.git --single-branch
 WORKDIR /app/kaoto-ui
 RUN yarn install --mode=skip-build
-RUN KAOTO_API="" yarn run build
+RUN KAOTO_API="." yarn run build
 
 #Backend build
 FROM registry.access.redhat.com/ubi8/openjdk-17:1.16 as BACKEND
@@ -35,4 +35,3 @@ EXPOSE 8080
 USER 185
 ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dquarkus.kubernetes-client.trust-certs=true"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
-

--- a/Dockerfile.native
+++ b/Dockerfile.native
@@ -5,7 +5,7 @@ WORKDIR /app
 RUN git clone --depth 1 --branch ${UI_TAG} https://github.com/KaotoIO/kaoto-ui.git --single-branch
 WORKDIR /app/kaoto-ui
 RUN yarn install --mode=skip-build
-RUN KAOTO_API="" yarn run build
+RUN KAOTO_API="." yarn run build
 
 #Backend build
 FROM quay.io/quarkus/ubi-quarkus-native-image:22.3-java17 as BACKEND
@@ -36,4 +36,3 @@ EXPOSE 8081
 USER 1001
 
 CMD ["./application", "-Dquarkus.http.host=0.0.0.0", "-Djava.util.logging.manager=org.jboss.logmanager.LogManager", "-Dquarkus.kubernetes-client.trust-certs=true"]
-


### PR DESCRIPTION
### Context
Setting an empty path to `KAOTO_API` makes the UI use the host as the base path for the API calls

![image](https://github.com/KaotoIO/kaoto-standalone/assets/16512618/a3de2433-e9b9-4cef-bdc8-ae1548d96d42)

### Changes
Setting `KAOTO_API="."` makes the path relative to the `index.html` file.

![image](https://github.com/KaotoIO/kaoto-standalone/assets/16512618/3236058c-cb53-43d0-b4d6-e0872cd62b1e)

### How to try it in the browser

1. Go to the developer tools
2. Open the debugger tab
3. Open the `requestService.ts` file
4. Set a breakpoint [in this line](https://github.com/KaotoIO/kaoto-ui/blob/4a683b9f7bfad3ed91caa7220d34bb0945ff5ffb/src/api/requestService.ts#L101)
5. Refresh the page and when the breakpoint stops, replace the `apiUrl` variable with `.` (dot)

![image](https://github.com/KaotoIO/kaoto-standalone/assets/16512618/ac9a1f99-2614-4f97-bd3b-4ddc3986ced2)

6. Once replaced, continue with the execution, now the UI should load properly.