### PR TITLE
chore: Update UI build to incorporate monorepo changes

### DIFF
--- a/Dockerfile.jvm
+++ b/Dockerfile.jvm
@@ -4,8 +4,8 @@ ARG UI_TAG=main
 WORKDIR /app
 RUN git clone --depth 1 --branch ${UI_TAG} https://github.com/KaotoIO/kaoto-ui.git --single-branch
 WORKDIR /app/kaoto-ui
-RUN yarn install --mode=skip-build
-RUN KAOTO_API="." yarn run build
+RUN yarn workspaces focus @kaoto/kaoto-ui
+RUN KAOTO_API="." yarn workspace @kaoto/kaoto-ui run build
 
 #Backend build
 FROM registry.access.redhat.com/ubi8/openjdk-17:1.16 as BACKEND
@@ -17,7 +17,7 @@ WORKDIR /code
 RUN git clone --depth 1 --branch ${API_TAG} https://github.com/KaotoIO/kaoto-backend.git --single-branch
 WORKDIR /code/kaoto-backend
 RUN rm api/src/main/resources/META-INF/resources/*
-COPY --from=FRONTEND /app/kaoto-ui/dist/* api/src/main/resources/META-INF/resources/
+COPY --from=FRONTEND /app/kaoto-ui/packages/kaoto-ui/dist/* api/src/main/resources/META-INF/resources/
 RUN ./mvnw install -DskipTests
 
 FROM registry.access.redhat.com/ubi8/openjdk-17:1.16

--- a/Dockerfile.native
+++ b/Dockerfile.native
@@ -4,8 +4,8 @@ ARG UI_TAG=main
 WORKDIR /app
 RUN git clone --depth 1 --branch ${UI_TAG} https://github.com/KaotoIO/kaoto-ui.git --single-branch
 WORKDIR /app/kaoto-ui
-RUN yarn install --mode=skip-build
-RUN KAOTO_API="." yarn run build
+RUN yarn workspaces focus @kaoto/kaoto-ui
+RUN KAOTO_API="." yarn workspace @kaoto/kaoto-ui run build
 
 #Backend build
 FROM quay.io/quarkus/ubi-quarkus-native-image:22.3-java17 as BACKEND
@@ -18,7 +18,7 @@ WORKDIR /code
 RUN git clone --depth 1 --branch ${API_TAG} https://github.com/KaotoIO/kaoto-backend.git --single-branch
 WORKDIR /code/kaoto-backend
 RUN rm api/src/main/resources/META-INF/resources/*
-COPY --from=FRONTEND /app/kaoto-ui/dist/* api/src/main/resources/META-INF/resources/
+COPY --from=FRONTEND /app/kaoto-ui/packages/kaoto-ui/dist/* api/src/main/resources/META-INF/resources/
 RUN ./mvnw install -Pnative -DskipTests
 
 #Final image


### PR DESCRIPTION
### Context
After `kaoto-ui` repository turned into a `monorepo`, we need to update how the UI part is built.

Relates to this pull request: https://github.com/KaotoIO/kaoto-ui/pull/2158
fixes: https://github.com/KaotoIO/kaoto-ui/issues/2159